### PR TITLE
flesh out Dockerfile for batch or lambda mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
+FROM ghcr.io/astral-sh/uv:0.6.6 AS uv
+
 FROM ghcr.io/lambgeo/lambda-gdal:3.8-python3.11 as gdal
 
-FROM public.ecr.aws/lambda/python:3.11
+FROM public.ecr.aws/lambda/python:3.11 as builder
 
 # Bring C libs from lambgeo/lambda-gdal image
 COPY --from=gdal /opt/lib/ ${LAMBDA_TASK_ROOT}/lib/
@@ -19,13 +21,45 @@ RUN yum update -y && \
   yum install -y git libxml2-devel libxslt-devel python-devel gcc && \
   yum clean all && \
   rm -rf /var/cache/yum /var/lib/yum/history
- 
-COPY pyproject.toml ${LAMBDA_TASK_ROOT}/pyproject.toml
-COPY src/task.py ${LAMBDA_TASK_ROOT}/task.py
 
-RUN uv sync
-RUN pip install --no-cache-dir -r requirements.txt
+# Enable bytecode compilation, to improve cold-start performance.
+ENV UV_COMPILE_BYTECODE=1
+
+# Disable installer metadata, to create a deterministic layer.
+ENV UV_NO_INSTALLER_METADATA=1
+
+# Enable copy mode to support bind mount caching.
+ENV UV_LINK_MODE=copy
+
+# Bundle the dependencies into the Lambda task root via `uv pip install --target`.
+#
+# Omit any local packages (`--no-emit-workspace`) and development dependencies (`--no-dev`).
+# This ensures that the Docker layer cache is only invalidated when the `pyproject.toml` or `uv.lock`
+# files change, but remains robust to changes in the application code.
+RUN --mount=from=uv,source=/uv,target=/bin/uv \
+    --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=README.md,target=README.md \
+    --mount=type=bind,source=src,target=src \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv export --frozen --no-emit-workspace --no-dev --no-editable -o requirements.txt && \
+    uv pip install -r requirements.txt --target "${LAMBDA_TASK_ROOT}" .
+
+
+FROM public.ecr.aws/lambda/python:3.11
+
+# Copy the runtime dependencies from the builder stage.
+COPY --from=builder ${LAMBDA_TASK_ROOT} ${LAMBDA_TASK_ROOT}
+
+COPY src/cirrus_task_example/ ${LAMBDA_TASK_ROOT}/cirrus_task_example/
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 
-ENTRYPOINT []
+# Uncomment one of the following:
+
+# 1. for lambda task, use CMD
+CMD [ "cirrus_task_example.task.lambda_handler" ]
+
+# 2. for batch task, use ENTRYPOINT
+#ENV PYTHONPATH="/var/task"
+#ENTRYPOINT [ "./bin/cirrus-task-example" ]

--- a/src/cirrus_task_example/task.py
+++ b/src/cirrus_task_example/task.py
@@ -13,7 +13,7 @@ class CirrusTaskExample(Task):
         return True
 
     def process(self, **kwargs: Any) -> list[dict[str, Any]]:
-        if "invalid" in self.process_definition["id"]:
+        if "invalid" in self.process_definition.get("id", ""):
             raise Exception("invalid")
 
         # create an item
@@ -48,6 +48,10 @@ class CirrusTaskExample(Task):
 
         # return a list of Items
         return [item.to_dict()]
+
+
+def lambda_handler(event: dict, context: dict = {}):
+    return CirrusTaskExample.handler(payload=event)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This merges the [lambgeo docker pattern](https://github.com/lambgeo/docker-lambda?tab=readme-ov-file#1-create-dockerfile) with the [uv pattern](https://docs.astral.sh/uv/guides/integration/aws-lambda/).  Tested locally with curl (lambda), and cli (batch).