### PR TITLE
Dots not dashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,25 @@ This project adheres to [CalVer](https://calver.org/). See the
 [README](README.md#versions-and-releases) for the specific CalVer format
 used by this project.
 
-## [v2025-03-12]
+## [Unreleased]
+
+### Added
+
+- Versioning section to README.md, and switched to using dot-delimited CalVer.
+
+## [v2025.03.12]
 
 ### Changed
 
 - Dockerfile now uses UV build scheme, along with lambgeo base. ([#2])
 - CLI specified via pyproject.toml. ([#1])
 
-## [v2025-03-11]
+## [v2025.03.11]
 
 Initial release
 
-[unreleased]: https://github.com/cirrus-geo/cirrus-task-example/compare/v2025-03-12..main
-[v2025-03-12]: https://github.com/cirrus-geo/cirrus-task-example/compare/v2025-03-11..v2025-03-12
-[v2025-03-11]: https://github.com/cirrus-geo/cirrus-task-example/tree/v2025-03-11
+[unreleased]: https://github.com/cirrus-geo/cirrus-task-example/compare/v2025.03.12..main
+[v2025.03.12]: https://github.com/cirrus-geo/cirrus-task-example/compare/v2025.03.11..v2025.03.12
+[v2025.03.11]: https://github.com/cirrus-geo/cirrus-task-example/tree/v2025.03.11
 [#1]: https://github.com/cirrus-geo/cirrus-task-example/pull/1
 [#2]: https://github.com/cirrus-geo/cirrus-task-example/pull/2

--- a/README.md
+++ b/README.md
@@ -68,3 +68,17 @@ To run the tests:
 ```
 uv run pytest
 ```
+
+# Versions and Releases
+
+![CalVer:YYYY.0M.0D\_MICRO](https://img.shields.io/badge/CalVer-YYYY.0M.0D__MICRO-00aa00.svg)
+
+This project uses CalVer for versioning releases.  The format is specified as
+`YYYY.0M.0D_MICRO`, where the tokens are:
+
+| token | description                     | example(s)             |
+|-------|---------------------------------|------------------------|
+| YYYY  | the full year                   | 2006, 2016, 2106)      |
+| 0M    | the zero-padded month           | 01, 02 ... 11, 12      |
+| 0D    | the zero-padded day of month    | 01, 02 ... 30, 31      |
+| MICRO | (optional) free form, as needed | alpha, rc0, post0, ... |


### PR DESCRIPTION
## Proposal

Use ![CalVer:YYYY.0M.0D\_MICRO](https://img.shields.io/badge/CalVer-YYYY.0M.0D__MICRO-00aa00.svg)

## Reasoning

In moving to fill in the missing `#versioning-and-releases` section of the `README.md` (pointed to by `CHANGELOG.md`), I realized I prefer dot-delimited CalVer.  Then I thought further, and as this is a python package, it would probably be best served to have a [PEP-0440](https://peps.python.org/pep-0440/) complatible versioning scheme.  CalVer with dashes is not.  But if you use dots then it should be good to go.

## Additional work

On approval of this PR, @ircwaves will merge and update the tags.